### PR TITLE
fix variable char length

### DIFF
--- a/lib/csv/_init.ttl
+++ b/lib/csv/_init.ttl
@@ -12,7 +12,7 @@ endif
 
 ifdefined csv_max_rows
 if result == 0 then
-  csv_max_rows = 1000
+  csv_max_rows = 999
 elseif result != 1 then
   message = 'csv_max_rows is not defined as an integer variable.'
   include 'lib\sys\log.ttl'

--- a/lib/csv/export-row.ttl
+++ b/lib/csv/export-row.ttl
@@ -3,7 +3,7 @@ if result = 0 then
   refname = 'csv'
 endif
 
-sprintf '_csv_column = csv_column_%s' refname
+sprintf '_csv_column = csv_col_%s' refname
 execcmnd inputstr
 sprintf '_csv_row = csv_row_%s' refname
 execcmnd inputstr
@@ -21,10 +21,10 @@ if _csv_row < row || row < 0 then
   exit
 endif
 
-sprintf2 _execcmnds[0] '_key = csv_headers_%s[_i]' refname
+sprintf2 _execcmnds[0] '_key = csv_hdrs_%s[_i]' refname
 for _i 0 _csv_column
   execcmnd _execcmnds[0]
-  sprintf '%s = csv_rows_%s_%d[row]' _key refname _i
+  sprintf '%s = csv_rs_%s_%d[row]' _key refname _i
   execcmnd inputstr
 next
 result = 1

--- a/lib/csv/load.ttl
+++ b/lib/csv/load.ttl
@@ -14,6 +14,11 @@ endif
 strlen refname
 if result == 0 then
   refname = 'csv'
+elseif result > 20 then
+  sprintf2 message 'refname is too long: %s' refname
+  include 'lib\sys\log.ttl'
+  result = 0
+  exit
 endif
 
 ; load csv file
@@ -26,13 +31,13 @@ if fhandle < 0 then
 endif
 
 ; read csv header
-sprintf 'ifdefined csv_headers_%s' refname
+sprintf 'ifdefined csv_hdrs_%s' refname
 execcmnd inputstr
 if result == 0 then
-  sprintf 'strdim csv_headers_%s csv_max_column+1' refname
+  sprintf 'strdim csv_hdrs_%s csv_max_column+1' refname
   execcmnd inputstr
 elseif result != 6 then
-  sprintf2 message 'csv_headers_%s is not defined as a string array variable.' refname
+  sprintf2 message 'csv_hdrs_%s is not defined as a string array variable.' refname
   include 'lib\sys\log.ttl'
   result = 0
   exit
@@ -70,16 +75,16 @@ for _i 0 _len
     result = 0
     call _error
   endif
-  sprintf 'csv_headers_%s[_i] = _csv_line_fields[_i]' refname
+  sprintf 'csv_hdrs_%s[_i] = _csv_line_fields[_i]' refname
   execcmnd inputstr
-  sprintf 'strdim csv_rows_%s_%d %d' refname _i csv_max_rows
+  sprintf 'strdim csv_rs_%s_%d %d' refname _i csv_max_rows
   execcmnd inputstr
-  sprintf2 _csv_execcmnds[_i] 'csv_rows_%s_%d[csv_row_%s] = _csv_line_fields[_i]' refname _i refname
+  sprintf2 _csv_execcmnds[_i] 'csv_rs_%s_%d[csv_row_%s] = _csv_line_fields[_i]' refname _i refname
 next
 
 ; read csv rows
 _csv_column = _len
-sprintf 'csv_column_%s = _len' refname
+sprintf 'csv_col_%s = _len' refname
 execcmnd inputstr
 
 sprintf 'csv_row_%s = -1' refname

--- a/lib/ini/export-section.ttl
+++ b/lib/ini/export-section.ttl
@@ -11,16 +11,16 @@ if result == 0 then
   exit
 endif
 
-sprintf '_s_size = ini_section_%s' refname
+sprintf '_s_size = ini_sec_%s' refname
 execcmnd inputstr
 
 for _i 0 _s_size
-  sprintf 'strcompare section ini_sections_%s[_i]' refname
+  sprintf 'strcompare section ini_secs_%s[_i]' refname
   execcmnd inputstr
   if result = 0 break
 next
 
-sprintf '_s_cmnd = ini_parameters_%s_%s[_i]' refname section
+sprintf '_s_cmnd = ini_prms_%s_%s[_i]' refname section
 
 for _i 0 1000
   execcmnd inputstr

--- a/lib/ini/load.ttl
+++ b/lib/ini/load.ttl
@@ -16,6 +16,11 @@ endif
 strlen refname
 if result = 0 then
   refname = 'ini'
+elseif result > 20 then
+  sprintf2 message 'refname is too long: %s' refname
+  include 'lib\sys\log.ttl'
+  result = 0
+  exit
 endif
 
 ; load ini file
@@ -27,20 +32,20 @@ if fhandle < 0 then
   exit
 endif
 
-sprintf 'ifdefined ini_sections_%s 100' refname
+sprintf 'ifdefined ini_secs_%s 100' refname
 execcmnd inputstr
 if result = 0 then
-  sprintf 'strdim ini_sections_%s 100' refname
+  sprintf 'strdim ini_secs_%s 100' refname
   execcmnd inputstr
 elseif result != 6 then
-  sprintf2 message 'ini_sections_%s is not strarr: %d' refname result
+  sprintf2 message 'ini_secs_%s is not strarr: %d' refname result
   include 'lib\sys\log.ttl'
   fileclose fhandle
   result = 0
   exit
 endif
 
-sprintf 'ifdefined ini_sections_%s 100' refname
+sprintf 'ifdefined ini_secs_%s 100' refname
 execcmnd inputstr
 sprintf 'defined: %d' result
 
@@ -76,15 +81,27 @@ while 1
   if _result & $4 then ; line type: comment
     continue
   elseif _result & $2 then ; line type section
-    sprintf 'ini_sections_%s[_s_size] = groupmatchstr3' refname
+    strlen groupmatchstr3
+    _i_value = result
+    strlen refname
+    _i_value = _i_value + result
+    if _i_value > 20 then
+      _i_value = 20 - result
+      sprintf2 message '(INI) section name is too long: limit < %d' _i_value
+      include 'lib\sys\log.ttl'
+      fileclose fhandle
+      result = 0
+      exit
+    endif
+    sprintf 'ini_secs_%s[_s_size] = groupmatchstr3' refname
     execcmnd inputstr
-    sprintf 'ifdefined ini_parameters_%s_%s' refname groupmatchstr3
+    sprintf 'ifdefined ini_prms_%s_%s' refname groupmatchstr3
     execcmnd inputstr
     if result = 0 then
-      sprintf 'strdim ini_parameters_%s_%s 1000' refname groupmatchstr3
+      sprintf 'strdim ini_prms_%s_%s 1000' refname groupmatchstr3
       execcmnd inputstr
     endif
-    sprintf 'ini_section_%s = _s_size' refname
+    sprintf 'ini_sec_%s = _s_size' refname
     execcmnd inputstr
     _s_name = groupmatchstr3
     _s_size = _s_size + 1
@@ -98,7 +115,7 @@ while 1
       result = 0
       exit
     endif
-    sprintf 'ini_parameters_%s_%s[_p_size] = groupmatchstr4' refname _s_name
+    sprintf 'ini_prms_%s_%s[_p_size] = groupmatchstr4' refname _s_name
     execcmnd inputstr
     _p_size = _p_size + 1
   endif
@@ -107,7 +124,7 @@ endwhile
 ; exit loading ini
 fileclose fhandle
 if _p_size > 0 then
-  sprintf 'ini_parameters_%s_%s[_p_size] = ""' refname _s_name
+  sprintf 'ini_prms_%s_%s[_p_size] = ""' refname _s_name
   execcmnd inputstr
 endif
 

--- a/lib/sys/_init.ttl
+++ b/lib/sys/_init.ttl
@@ -48,11 +48,11 @@ include 'lib\sys\log.ttl'
 
 for i 0 100
   section = 'global'
-  strlen ini_sections_config[i]
+  strlen ini_secs_config[i]
   if result == 0 then
     break
   endif
-  strcompare ini_sections_config[i] section
+  strcompare ini_secs_config[i] section
   if result == 0 then
     include 'lib\ini\export-section.ttl'
     break

--- a/lib/sys/_scenario.ttl
+++ b/lib/sys/_scenario.ttl
@@ -36,17 +36,19 @@ if result = 1 then
   sprintf2 message '===== Load scenario: %s =====' scenario
   include 'lib\sys\log.ttl'
 
+  refname = '_tc'
   include 'lib\ini\load.ttl'
   if result == 0 then
     exit
   endif
 
-  sprintf '_scenario_size = ini_section_%s' refname
+  sprintf '_scenario_size = ini_sec_%s' refname
   execcmnd inputstr
-  sprintf2 _scenario_cmnd 'section = ini_sections_%s[_scenario_i]' refname
+  sprintf2 _scenario_cmnd 'section = ini_secs_%s[_scenario_i]' refname
   for _scenario_i 0 _scenario_size
     api_continue = 1
     execcmnd _scenario_cmnd
+    refname = '_tc'
     include 'lib\ini\export-section.ttl'
 
     include 'lib\sys\_api.ttl'

--- a/teracotta.ttl
+++ b/teracotta.ttl
@@ -12,7 +12,7 @@ else
   filename = 'hosts.csv'
 endif
 
-refname = 'inventory'
+refname = '_tc'
 is_header = 1
 include 'lib\csv\load.ttl'
 
@@ -26,8 +26,9 @@ if result != 0 then
   scenario = param3
 endif
 
-for inventory_row 0 csv_row_inventory
+for inventory_row 0 csv_row__tc
   row = inventory_row
+  refname = '_tc'
   include 'lib\csv\export-row.ttl'
 
   sprintf2 message '* Loaded host parameters: %s *' sysname


### PR DESCRIPTION
#10 対応

- CSVの最大行数を1000→999にした(変数の文字列に行数を含めているため)
- CSVのヘッダー名 最大文字列長を20文字、INIのセクション名最大文字列長を19文字まで増やした。
  ちょっと仕様変えればもっと伸ばせるんだけど、とりあえずこれで暫定
- 最大文字列長を超えた場合はエラー