### PR TITLE
CSVの囲み文字に対応

### DIFF
--- a/lib/csv/debug.ttl
+++ b/lib/csv/debug.ttl
@@ -3,16 +3,16 @@ if result = 0 then
   refname = 'csv'
 endif
 
-sprintf '_csv_column = csv_column_%s' refname
+sprintf '_csv_col = csv_col_%s' refname
 execcmnd inputstr
 
 sprintf '_csv_row = csv_row_%s' refname
 execcmnd inputstr
 
-sprintf2 message 'ref: %s, column: %d, row: %d' refname _csv_column _csv_row
+sprintf2 message 'ref: %s, column: %d, row: %d' refname _csv_col _csv_row
 include 'lib\sys\log.ttl'
 
-if _csv_column = 0 then
+if _csv_col = 0 then
   sprintf2 message 'csv file is not load'
   include 'lib\sys\log.ttl'
   result = 0
@@ -21,9 +21,9 @@ endif
 
 message = '|'
 _separator = '|'
-sprintf2 _execcmnds[0] '_key = csv_headers_%s[i]' refname
+sprintf2 _execcmnds[0] '_key = csv_hdrs_%s[_i]' refname
 
-for _i 0 _csv_column
+for _i 0 _csv_col
   strconcat _separator '----|'
   execcmnd _execcmnds[0]
   sprintf2 message '%s %s |' message _key
@@ -35,8 +35,8 @@ include 'lib\sys\log.ttl'
 if _csv_row >= 0 then
   for _i 0 _csv_row
     message = '|'
-    for _j 0 _csv_column
-      sprintf '_s_value = csv_rows_%s_%d[_i]' refname _j
+    for _j 0 _csv_col
+      sprintf '_s_value = csv_rs_%s_%d[_i]' refname _j
       execcmnd inputstr
       sprintf2 message '%s %s |' message _s_value
     next

--- a/lib/csv/load.ttl
+++ b/lib/csv/load.ttl
@@ -1,6 +1,7 @@
 ; load csv library
 _filename = filename
 filename = ''
+sprintf2 _re_field '^,?\s*(?:%s|%s|([^,]*))\s*' '"([^"]*)"' "'([^']*)'"
 
 ; initialization
 filesearch _filename
@@ -109,14 +110,21 @@ exit
 :_csv_readline
 _len = 0
 for _i 0 csv_max_column
-  strscan _line ','
-  if result > 0 then
-    strcopy _line 1 result-1 _csv_line_fields[_i]
-    strremove _line 1 result
-  else
-    _csv_line_fields[_i] = _line
-    if _len == 0 _len = _i
-  endif
+  _s_value = ''
+
+  strreplace _line 1 _re_field ''
+  strlen groupmatchstr1
+  if result > 0 _s_value = groupmatchstr1
+
+  strlen groupmatchstr2
+  if result > 0 _s_value = groupmatchstr2
+
+  strlen groupmatchstr3
+  if result > 0 _s_value = groupmatchstr3
+
+  strlen _s_value
+  if result == 0 && _len == 0 _len = _i
+  _csv_line_fields[_i] = _s_value
 next
 return
 

--- a/lib/sys/_init.ttl
+++ b/lib/sys/_init.ttl
@@ -3,6 +3,8 @@ _init_ver = '4.78'
 teracotta_ver = '0.1.2'
 api_ver = '0.1.1'
 
+TC_ENCODING = 'SJIS'
+
 ; initialize libraries
 include 'lib\csv\_init.ttl'
 include 'lib\ini\_init.ttl'
@@ -60,5 +62,4 @@ for i 0 100
 next
 ifdefined config_sections_size
 
-;regexoption 'OPTION_SINGLELINE'
-
+regexoption TC_ENCODING


### PR DESCRIPTION
囲み文字にダブルクォーテーション、シングルクォーテーションが使えるようになりました。 ( #3 )

従来どおり囲み文字なしも使えます。

ついでに `lib\csv\debug.ttl` も不具合放置してたのを直しました。