### PR TITLE
add new library `lib\str\format.ttl`

### DIFF
--- a/lib/str/format.ttl
+++ b/lib/str/format.ttl
@@ -1,0 +1,42 @@
+_message = message
+_fmt_key = ''
+_fmt_value = ''
+
+strlen _message
+do while result > 0
+  strreplace _message 1 '^[^{]*({(([a-zA-Z0-9_]+)(\[[0-9a-zA-Z_]+\])?)})?' ''
+  strlen groupmatchstr1
+  if result > 0 then
+    _fmt_key = groupmatchstr1
+    strlen groupmatchstr4
+    _result = result
+    sprintf 'ifdefined %s' groupmatchstr3
+    execcmnd inputstr
+    if result == 1 && _result == 0 then
+      sprintf 'int2str _fmt_value %s' groupmatchstr2
+      execcmnd inputstr
+    elseif result == 3 && _result == 0 then
+      sprintf '_fmt_value = %s' groupmatchstr2
+      execcmnd inputstr
+    elseif result == 5 && _result != 0 then
+      sprintf 'int2str _fmt_value %s' groupmatchstr2
+      execcmnd inputstr
+      strreplace _fmt_key 1 '\[' '\['
+      strreplace _fmt_key 1 '\]' '\]'
+    elseif result == 6 && _result != 0 then
+      sprintf '_fmt_value = %s' groupmatchstr2
+      execcmnd inputstr
+      strreplace _fmt_key 1 '\[' '\['
+      strreplace _fmt_key 1 '\]' '\]'
+    else
+      sprintf2 message '(Format)Invalid argument: %s' groupmatchstr2
+      include 'lib\sys\log.ttl'
+      result = 0
+      exit
+    endif
+    strreplace message 1 _fmt_key _fmt_value
+  endif
+  strlen _message
+loop
+
+result = 1


### PR DESCRIPTION
sprintfで十分な気もしますが……なんとなく作ってしまったのでマージします。

文字列内の `{varname}` を変数 `vername` の値に置き換えます。

例えば以下のような処理を書くことが出来るようになります。

```
hoge = 1
foo = 'bar'
intdim piyo 3
piyo[1] = 2
message = '{hoge} {foo} {piyo[1]}'
include 'lib\str\format.ttl'

; display: "1 bar 2"
messagebox message 'title'
```

sprintf/sprintf2と違うところとしては、変数の型を自動判定してくれるところでしょうか。

整数値、文字列、配列整数値、配列文字列すべてを同じような書き方で表現することが出来ます。

また、配列に関してはインデックスに変数も利用できます。