### PR TITLE
一般的なINIファイルを読み込めるようにする(他)

### DIFF
--- a/api/_global/connect_ssh.ttl
+++ b/api/_global/connect_ssh.ttl
@@ -3,7 +3,7 @@
 
 ; [入力値]
 ; (string)port: TCPポート番号(1-) default:22
-; (integer)ssh_ver: SSHバージョン(1|2) default:2
+; (string)ssh_ver: SSHバージョン(1|2) default:2
 ; (string)auth: 認証方法(password/publickey/challenge/pageant) default:password
 ; (string)dest: 接続先(IPまたはホスト名)
 ; (string)loginuser: ユーザ名
@@ -29,8 +29,13 @@ endif
 
 ifdefined ssh_ver
 if result = 0 then
-  ssh_ver = 2
-elseif result != 1 then
+  _ssh_ver = 2
+elseif result == 3 then
+  str2int _ssh_ver ssh_ver
+  if result == 0 || (_ssh_ver >= 1 && _ssh_ver <= 2) then
+    _ssh_ver = 2
+  endif
+else
   result = 0
   exit
 endif
@@ -49,7 +54,7 @@ if result = 0 || result != 3 then
   exit
 endif
 
-sprintf '%s:%d /ssh /%d /auth=%s' dest _port ssh_ver auth
+sprintf '%s:%d /ssh /%d /auth=%s' dest _port _ssh_ver auth
 
 ifdefined loginuser
 if result = 3 then

--- a/api/_global/logopen.ttl
+++ b/api/_global/logopen.ttl
@@ -53,6 +53,8 @@ if result == 0 then
   result = 0
   exit
 endif
+getdir inputstr
+sprintf2 _logfilename '%s\%s' inputstr logfilename
 
 _refname = refname
 _section = section
@@ -65,15 +67,13 @@ include 'lib\ini\export-section.ttl'
 refname = _refname
 section = _section
 
-getdir inputstr
-sprintf '%s\%s' inputstr logfilename
+sprintf 'logopen _logfilename %s %s %s %s %s' is_binary is_append is_plain is_timestamp is_hide
 
 getver _s_value '4.80'
 if result >= 0 then
-  logopen inputstr is_binary is_append is_plain is_timestamp is_hide is_buffer
-else
-  logopen inputstr is_binary is_append is_plain is_timestamp is_hide
+  sprintf '%s %s' inputstr is_buffer
 endif
+execcmnd inputstr
 
 if result == 1 then
   sprintf2 message '(Log) could not open: %s' logfilename
@@ -82,18 +82,32 @@ if result == 1 then
   exit
 endif
 
-sprintf2 message '(Log) start to get log: %s' inputstr
+sprintf2 message '(Log) start to get log: %s' _logfilename
 include 'lib\sys\log.ttl'
 
 ifdefined is_logrotate
-if result == 1 && is_logrotate == 1 then
+if result == 3 then
+  message = is_logrotate
+else
+  message = 'no'
+endif
+include 'lib\str\str2bool.ttl'
+_is_logrotate = bool
+
+ifdefined logrotate_rotate
+if result == 3 then
+  str2int _logrotate_rotate logrotate_rotate
+else
+  _logrotate_rotate = 0
+endif
+
+if _is_logrotate == 1 then
   ifdefined logrotate_size
   if result == 3 then
     logrotate 'size' logrotate_size
   endif
-  ifdefined logrotate_rotate
-  if result == 1 then
-    logrotate 'rotate' logrotate_rotate
+  if _logrotate_rotate > 0 then
+    logrotate 'rotate' _logrotate_rotate
   endif
 endif
 

--- a/api/cisco-ios/raw_command.ttl
+++ b/api/cisco-ios/raw_command.ttl
@@ -4,7 +4,7 @@ sendln command
 sprintf '%s.*%s' prompt_re command
 waitregex inputstr
 do
-  wait prompt #13'% ' '--More--'
+  wait prompt #10'% ' '--More--'
   if result == 1 then
     break
   elseif result == 2 then

--- a/api/cisco-ios/raw_command_logging.ttl
+++ b/api/cisco-ios/raw_command_logging.ttl
@@ -19,7 +19,7 @@ sprintf '%s.*%s' prompt_re command
 waitregex inputstr
 
 do
-  wait prompt #13'% ' #13 '--More--'
+  wait prompt #10'% ' #10 '--More--'
   if result == 1 then
     break
   elseif result == 2 then

--- a/api/fortios/raw_command.ttl
+++ b/api/fortios/raw_command.ttl
@@ -8,7 +8,7 @@ do
   if result == 1 then
     break
   elseif result > 1 then
-    message = '(IOS) command error: '
+    message = '(FortiOS) command error: '
     strconcat message command
     include 'lib\sys\log.ttl'
     recvln

--- a/api/fortios/raw_command_logging.ttl
+++ b/api/fortios/raw_command_logging.ttl
@@ -21,7 +21,7 @@ sendln command
 sprintf '%s.*%s' prompt_re command
 waitregex inputstr
 do
-  wait prompt #13 '--More--' 'Unknown action' 'Command fail'
+  wait prompt #10 '--More--' 'Unknown action' 'Command fail'
   if result == 1 then
     break
   elseif result == 2 then

--- a/api/screenos/raw_command_logging.ttl
+++ b/api/screenos/raw_command_logging.ttl
@@ -18,7 +18,7 @@ sendln command
 sprintf '%s.*%s' prompt_re command
 waitregex inputstr
 do
-  wait prompt #13 '^--' '--- more ---'
+  wait prompt #10 '^--' '--- more ---'
   if result == 1 then
     break
   elseif result == 2 then

--- a/lib/csv/load.ttl
+++ b/lib/csv/load.ttl
@@ -1,7 +1,7 @@
 ; load csv library
 _filename = filename
 filename = ''
-sprintf2 _re_field '^,?\s*(?:%s|%s|([^,]*))\s*' '"([^"]*)"' "'([^']*)'"
+sprintf2 _re_field '^,?\s*(?:%s|%s|([^,]*))?\s*' '"([^"]*)"' "'([^']*)'"
 
 ; initialization
 filesearch _filename
@@ -113,17 +113,18 @@ for _i 0 csv_max_column
   _s_value = ''
 
   strreplace _line 1 _re_field ''
-  strlen groupmatchstr1
-  if result > 0 _s_value = groupmatchstr1
+  if result > 0 then
+    strlen groupmatchstr1
+    if result > 0 _s_value = groupmatchstr1
 
-  strlen groupmatchstr2
-  if result > 0 _s_value = groupmatchstr2
+    strlen groupmatchstr2
+    if result > 0 _s_value = groupmatchstr2
 
-  strlen groupmatchstr3
-  if result > 0 _s_value = groupmatchstr3
-
+    strlen groupmatchstr3
+    if result > 0 _s_value = groupmatchstr3
+  endif
   strlen _s_value
-  if result == 0 && _len == 0 _len = _i
+  if result == 0 && _len == 0 _len = _i - 1
   _csv_line_fields[_i] = _s_value
 next
 return

--- a/lib/ini/load.ttl
+++ b/lib/ini/load.ttl
@@ -62,7 +62,7 @@ while 1
   strlen _line
   if result == 0 continue ; line type: blank
 
-  strmatch _line "^(?:([;#]).*|(\[)([^\]]+)\]|(\S+\s*(=)\s*.+))$"
+  strmatch _line "^(?:([;#]).*|(\[)([^\]]+)\]|([a-zA-Z0-9_]+)\s*(=)\s*[']?(.*?)[']?)$"
   if result == 0 then
     sprintf2 message '(INI) could not parsed[line %d]' _i
     include 'lib\sys\log.ttl'
@@ -115,7 +115,8 @@ while 1
       result = 0
       exit
     endif
-    sprintf 'ini_prms_%s_%s[_p_size] = groupmatchstr4' refname _s_name
+    sprintf2 _command '%s = "%s"' groupmatchstr4 groupmatchstr6
+    sprintf 'ini_prms_%s_%s[_p_size] = _command' refname _s_name
     execcmnd inputstr
     _p_size = _p_size + 1
   endif

--- a/lib/str/str2bool.ttl
+++ b/lib/str/str2bool.ttl
@@ -1,0 +1,27 @@
+; logopen.ttl
+; 文字列で表現されたTrue/FolseなどのBoolean値を整数型の0または1に変換します。
+
+; [入力値]
+; (string)message: 判定する文字列
+
+; [戻り値]
+; (integer)bool: 判定結果(true,ok,onなどで1, false,ng,offなどで0, その他の場合-1)
+; (integer)result: 正しく変換できたら1、そうでない場合は0
+
+regexoption TC_SYNTAX TC_ENCODING 'OPTION_IGNORECASE'
+strmatch message '^(?:(t(?:rue)?|ok|on|yes)|(f(?:alse)?|ng|off|no))$'
+regexoption TC_SYNTAX TC_ENCODING TC_OPTION
+
+strlen groupmatchstr1
+_result = result
+strlen groupmatchstr2
+if _result > 0 && result == 0 then
+  bool = 1
+  result = 1
+elseif _result == 0 && result > 0 then
+  bool = 0
+  result = 1
+else
+  bool = -1
+  result = 0
+endif

--- a/lib/sys/_init.ttl
+++ b/lib/sys/_init.ttl
@@ -4,6 +4,8 @@ teracotta_ver = '0.1.2'
 api_ver = '0.1.1'
 
 TC_ENCODING = 'SJIS'
+TC_SYNTAX = 'SYNTAX_RUBY'
+TC_OPTION = 'OPTION_NONE'
 
 ; initialize libraries
 include 'lib\csv\_init.ttl'
@@ -62,4 +64,4 @@ for i 0 100
 next
 ifdefined config_sections_size
 
-regexoption TC_ENCODING
+regexoption TC_SYNTAX TC_ENCODING TC_OPTION


### PR DESCRIPTION
#14 に引き続き、 #3 の対応。

関連して不具合とか出てきたので、色々と直した。

- 各ベンダー毎の `raw_command` において改行コードCRで検出しようとしてたので、LFに直しました。
- booleanな意味を持つ文字列を1/0に変換するライブラリ `str2bool.ttl` を追加
  `t|true|ok|yes|on` : 1を返す
  `f|false|ng|no|off` : 0を返す
  それ以外の文字列だった場合は-1を返します。
  ※大文字小文字の区別はありません。比較的自由ですね。
- さっき実装したCSVがなんかちゃんと動いてなかったので直した。

今までINIファイルと言いつつ独自仕様だった(パラメータに型の概念がある)。
そのためINIファイルから読み込めるデータ型は文字列型に統一。

(念の為以前のバージョンの互換性を残して囲み文字を削除する対応は残してある)

これでExcelVBAからのファイル出力も比較的楽になったかな。