### PR TITLE
Teracotta v0.2.0

### DIFF
--- a/api/_global/logopen.ttl
+++ b/api/_global/logopen.ttl
@@ -4,31 +4,31 @@
 ; config.ini の [log] セクションのパラメータを調整してください。
 
 ; [Config値]
-; (integer)is_binary: バイナリ出力
+; (string)is_binary: バイナリ出力
 ;   0: しない(漢字、改行コードなどは変換される)
 ;   1: する(漢字、改行コードなどはそのまま書き込まれる)
-; (integer)is_append: 追記モード
+; (string)is_append: 追記モード
 ;   0: 無効(ログ取得時、既存のテキストを消去する)
 ;   1: 有効(ログ取得時、既存のテキストに追記する)
-; (integer)is_plain: プレーン出力
+; (string)is_plain: プレーン出力
 ;   0: 無効(NULLなどASCII非表示文字を出力する)
 ;   1: 有効(ASCII非表示文字を出力しない)
-; (integer)is_timestamp: タイムスタンプ出力
+; (string)is_timestamp: タイムスタンプ出力
 ;   0: 無効(行頭にタイムスタンプを出力しない)
 ;   1: 有効(行頭にタイムスタンプを出力する)
-; (integer)is_hide: ログ転送ダイアログの非表示
+; (string)is_hide: ログ転送ダイアログの非表示
 ;   0: 表示
 ;   1: 非表示
-; (integer)is_buffer: スクリーンバッファを先に書き込む
+; (string)is_buffer: スクリーンバッファを先に書き込む
 ;   0: 無効
 ;   1: 有効
 ;   ※teraterm v4.80 以降でのみ有効になります。
-; (integer)is_logrotate: ログローテート設定の有効化
+; (string)is_logrotate: ログローテート設定の有効化
 ;   0: 無効
 ;   1: 有効
 ; (string)logrotate_size: ローテートサイズ(128-)
 ;   例: 1048576, 1024K, 1M
-; (integer)logrotate_count: ローテート世代数(3-)
+; (string)logrotate_count: ローテート世代数(3-)
 ;   指定した世代数だけファイルを保持し、古いファイルは順番に削除されます。
 
 ; [入力値]
@@ -67,13 +67,26 @@ include 'lib\ini\export-section.ttl'
 refname = _refname
 section = _section
 
-sprintf 'logopen _logfilename %s %s %s %s %s' is_binary is_append is_plain is_timestamp is_hide
+_command = 'logopen _logfilename'
+message = 'is_binary,is_append,is_plain,is_timestamp,is_hide'
+delimiter = ','
+include 'lib\str\strsplit.ttl'
+_last = result - 1
+for i 0 _last
+  variable = inputstr_arr[i]
+  include 'lib\str\str2bool.ttl'
+  result = result > 0
+  sprintf2 _command '%s %d' _command result
+next
 
 getver _s_value '4.80'
 if result >= 0 then
-  sprintf '%s %s' inputstr is_buffer
+  variable = 'is_buffer'
+  include 'lib\str\str2bool.ttl'
+  if result < 0 result = 0
+  sprintf2 _command '%s %d' _command result
 endif
-execcmnd inputstr
+execcmnd _command
 
 if result == 1 then
   sprintf2 message '(Log) could not open: %s' logfilename
@@ -85,29 +98,19 @@ endif
 sprintf2 message '(Log) start to get log: %s' _logfilename
 include 'lib\sys\log.ttl'
 
-ifdefined is_logrotate
-if result == 3 then
-  message = is_logrotate
-else
-  message = 'no'
-endif
+variable = 'is_logrotate'
 include 'lib\str\str2bool.ttl'
-_is_logrotate = bool
 
-ifdefined logrotate_rotate
-if result == 3 then
-  str2int _logrotate_rotate logrotate_rotate
-else
-  _logrotate_rotate = 0
-endif
-
-if _is_logrotate == 1 then
+if result > 0 then
   ifdefined logrotate_size
   if result == 3 then
     logrotate 'size' logrotate_size
   endif
-  if _logrotate_rotate > 0 then
-    logrotate 'rotate' _logrotate_rotate
+  variable = 'logrotate_rotate'
+  include 'lib\str\str2bool.ttl'
+  result = result > 0
+  if result == 1 then
+    logrotate 'rotate' result
   endif
 endif
 

--- a/api/_global/raw_command_logging.ttl
+++ b/api/_global/raw_command_logging.ttl
@@ -30,7 +30,7 @@ sprintf '%s.*%s' prompt_re command
 waitregex inputstr
 
 do
-  wait prompt #13
+  wait prompt #10
   if result = 1 then
     break
   elseif result = 2 then

--- a/api/cisco-ios/raw_command_logging.ttl
+++ b/api/cisco-ios/raw_command_logging.ttl
@@ -19,7 +19,7 @@ sprintf '%s.*%s' prompt_re command
 waitregex inputstr
 
 do
-  wait prompt #10'% ' #10 '--More--'
+  wait prompt #10'% ' #13 '--More--'
   if result == 1 then
     break
   elseif result == 2 then

--- a/api/fortios/raw_command_logging.ttl
+++ b/api/fortios/raw_command_logging.ttl
@@ -21,7 +21,7 @@ sendln command
 sprintf '%s.*%s' prompt_re command
 waitregex inputstr
 do
-  wait prompt #10 '--More--' 'Unknown action' 'Command fail'
+  wait prompt #13 '--More--' 'Unknown action' 'Command fail'
   if result == 1 then
     break
   elseif result == 2 then

--- a/api/screenos/raw_command_logging.ttl
+++ b/api/screenos/raw_command_logging.ttl
@@ -18,7 +18,7 @@ sendln command
 sprintf '%s.*%s' prompt_re command
 waitregex inputstr
 do
-  wait prompt #10 '^--' '--- more ---'
+  wait prompt #13 '^--' '--- more ---'
   if result == 1 then
     break
   elseif result == 2 then

--- a/config-example.ini
+++ b/config-example.ini
@@ -6,30 +6,30 @@
 ; この設定は logopen API を呼び出す際に利用されます。
 
 ; バイナリ出力: 漢字、改行コードなどを適切なコードに変換します。
-is_binary = 1
+is_binary=yes
 
 ; 追記モード: 既存ログが存在する場合に追記します。
-is_append = 0
+is_append=no
 
 ; プレーン出力: NULLなどのACSII非表示文字の出力を抑制します。
-is_plain = 1
+is_plain=yes
 
 ; タイムスタンプ出力: ログの行頭にタイムスタンプを挿入します。
-is_timestamp = 0
+is_timestamp=no
 
 ; ログ転送ダイアログの非表示: ログ開始時にログ転送ダイアログを非表示にします。
-is_hide = 1
+is_hide=yes
 
 ; スクリーンバッファ書き込み優先: ログ出力をしてから画面表示を行います。
 ; ※この設定はTeraterm v4.80 以降でのみ有効です。
-is_buffer = 1
+is_buffer=yes
 
 ; ログローテート設定の有効化: 特定バイト数ログ出力をしたらログファイルを切り替えます。
-is_logrotate = 0
+is_logrotate=no
 
 ; ローテートサイズ(128-): ログローテート有効時のログサイズ上限を設定します。
-logrotate_size = '1M'
+logrotate_size=1M
 
 ; ローテート世代数(3-): ログローテート有効時のログファイル保存数を設定します。
 ; ログファイル数が設定値を超えた場合、古いファイルから削除されます。
-logrotate_rotate = 10
+logrotate_rotate=10

--- a/lib/str/str2bool.ttl
+++ b/lib/str/str2bool.ttl
@@ -1,27 +1,47 @@
-; logopen.ttl
-; 文字列で表現されたTrue/FolseなどのBoolean値を整数型の0または1に変換します。
+; str2bool.ttl
+; 指定された変数を調査し、Boolean値として整数型の0または1に変換します。
 
 ; [入力値]
-; (string)message: 判定する文字列
+; (string)variable: 判定する変数(整数型、文字列型に対応)
 
 ; [戻り値]
-; (integer)bool: 判定結果(true,ok,onなどで1, false,ng,offなどで0, その他の場合-1)
-; (integer)result: 正しく変換できたら1、そうでない場合は0
+; (integer)result: 判定結果(以下のパターンが該当します)
 
+; 文字列型の場合：true,ok,on,yes,正の整数で1, false,ng,off,no,0以下の整数で0, それ以外で-1
+; 整数型の場合：正の整数で1, 0以下の整数で0
+; 変数未定義の場合：-1
+
+sprintf 'ifdefined %s' variable
+execcmnd inputstr
+
+if result == 0 then
+  result = -1
+  exit
+elseif result == 1 then
+  sprintf 'result = %s > 0' variable
+  execcmnd inputstr
+  exit
+endif
+
+_re = '^(?:(t(?:rue)?|ok|on|yes)|(f(?:alse)?|ng|off|no)|(-?[0-9]+))$'
 regexoption TC_SYNTAX TC_ENCODING 'OPTION_IGNORECASE'
-strmatch message '^(?:(t(?:rue)?|ok|on|yes)|(f(?:alse)?|ng|off|no))$'
+sprintf 'strmatch %s _re' variable
+execcmnd inputstr
 regexoption TC_SYNTAX TC_ENCODING TC_OPTION
 
-strlen groupmatchstr1
-_result = result
-strlen groupmatchstr2
-if _result > 0 && result == 0 then
-  bool = 1
-  result = 1
-elseif _result == 0 && result > 0 then
-  bool = 0
-  result = 1
+strlen groupmatchstr1 ; positive expression (0b0100)
+_result = (result > 0)
+strlen groupmatchstr2 ; negative expression (0b0010)
+_result = (_result << 1) + (result > 0)
+strlen groupmatchstr3 ; integer expression (0b0001)
+_result = (_result << 1) + (result > 0)
+
+
+if _result & $6 then ; positive/negative expression
+  result = _result & $4 > 0
+elseif _result & $1 then ; integer expression
+  str2int result groupmatchstr3
+  result = result > 0
 else
-  bool = -1
-  result = 0
+  result = -1
 endif

--- a/lib/str/strjoin.ttl
+++ b/lib/str/strjoin.ttl
@@ -1,0 +1,54 @@
+; strjoin.ttl
+; strjoinはマクロ関数として実装されていますが、配列として扱う際に不便なので用意しました。
+
+; [入力値]
+; (string)inputstr_arr: 結合する文字列配列
+; (string)delimiter: 区切り文字(デフォルトは',')
+; (integer)length: 結合する長さ(1000まで。未指定もしくは0以下の場合は空要素まで)
+
+; [戻り値]
+; (integer)result: 結合に成功したら1、失敗したら０
+; (string array) inputstr: 結合した文字列
+
+ifdefined inputstr_arr
+if result == 0 then
+  result = 0
+  exit
+endif
+
+ifdefined delimiter
+if result == 0 then
+  delimiter = ','
+elseif result != 3 then
+  result = 0
+  exit
+endif
+
+ifdefined length
+if result == 0 then
+  _length = 0
+elseif result != 1 then
+  result = 0
+  exit
+elseif length > 1000 then
+  _length = 1000
+else
+  _length = length
+endif
+messagebox _length length
+
+_i = 1
+inputstr = inputstr_arr[0]
+do
+  if _length <= 0 then
+    strlen inputstr_arr[_i]
+    if result == 0 then
+      break
+    endif
+  elseif _length <= _i then
+    break
+  endif
+  strconcat inputstr delimiter
+  strconcat inputstr inputstr_arr[_i]
+  _i = _i + 1
+loop

--- a/lib/str/strsplit.ttl
+++ b/lib/str/strsplit.ttl
@@ -1,0 +1,44 @@
+; strsplit.ttl
+; strsplitはマクロ関数として実装されていますが、配列として扱う際に不便なので用意しました。
+
+; [入力値]
+; (string)message: 分割する文字列
+; (string)delimiter: 区切り文字(デフォルトは',')
+
+; [戻り値]
+; (integer)result: 分割した要素数(エラーで0)
+; (string array) inputstr_arr: 分割した値(最大1000)
+
+ifdefined inputstr_arr
+if result == 0 then
+  strdim inputstr_arr 1000
+elseif result != 6 then
+  result = 0
+  exit
+endif
+
+ifdefined delimiter
+if result == 0 then
+  delimiter = ','
+elseif result != 3 then
+  result = 0
+  exit
+endif
+
+strlen delimiter
+if result == 0 then
+  delimiter = ','
+endif
+
+groupmatchstr2 = message
+for _i 1 1000
+  strsplit groupmatchstr2 delimiter 2
+  inputstr_arr[_i - 1] = groupmatchstr1
+  inputstr_arr[_i] = groupmatchstr2
+  strscan groupmatchstr2 delimiter
+  if result == 0 then
+    break
+  endif
+next
+
+result = _i + 1

--- a/lib/sys/_init.ttl
+++ b/lib/sys/_init.ttl
@@ -1,7 +1,7 @@
 ; initialize tool'
 _init_ver = '4.78'
-teracotta_ver = '0.1.2'
-api_ver = '0.1.1'
+teracotta_ver = '0.2.0'
+api_ver = '0.1.2'
 
 TC_ENCODING = 'SJIS'
 TC_SYNTAX = 'SYNTAX_RUBY'

--- a/scenario/scenario-example.ini
+++ b/scenario/scenario-example.ini
@@ -1,42 +1,41 @@
 ; ** Teracotta Scenario example **
 ; セクション毎に上から順にAPIを呼び出します。
 ; セクション名は任意ですが、一意のものにしてください。
-; パラメータ行にはteratermの代入文のみ設定できます。
-; 文字列にはシングルクォートかダブルクォートを用いてください。
+; セクション名の最大文字数は17程度です。(あまり長くしないでください)
 ; 各セクションにAPIパラメータは必須です。
 
 ; 設定サンプル(CiscoIOSのサポートログを取得する)
 
 ; 機器接続(hostsファイルtypeパラメータで接続種別設定)
 [part_0]
-API = 'connect'
+API=connect
 
 ; ログ取得開始
 [part_1]
-API = 'logopen'
+API=logopen
 
 ; 接続機器のログイン処理
 [part_2]
-API = 'login'
+API=login
 
 ; 特権モードに昇格
 [part_3]
-API = 'superuser'
+API=superuser
 
 ; ページング無効化コマンドを入力
 [part_4]
-API = 'raw_command'
-command = 'ter len 0'
+API=raw_command
+command=ter len 0
 
 ; サポート用コマンドを入力
 [part_5]
-API = 'raw_command'
-command = 'show tech-support'
+API=raw_command
+command=show tech-support
 
 ; 接続機器からログアウト
 [part_6]
-API = 'logout'
+API=logout
 
 ; ログ取得終了
 [part_7]
-API = 'logclose'
+API=logclose


### PR DESCRIPTION
INIサンプル直すために、ついでにアレを直してコレも直してして…としてたら結構大幅に直してついでにライブラリも追加してた。

- 新ライブラリ `lib\str\strjoin.ttl` `lib\str\strsplit.ttl`
  Teratermマクロに `strjoin` と `strsplit` はありますが、結果はgroupmatchstr1-9の中に入ります。
  恐らく文字列配列がない頃に実装されたのかな。よくわからないけど不便だったので、文字列配列に入れられるライブラリを作成しました。
  そのうちドキュメントを作成しますが、とりあえず当該ライブラリにコメントで使い方は書いてあります。
- `api\_global\logopen.ttl` と`lib\str\str2bool.ttl` を修正
  昨日実装したINIファイル読み込みで、bool判定してないINIコンフィグがあったので修正。
  ついでにstr2boolの機能を拡張して、文字列型以外にもbool判定出来るようにしました。
  ……ってこれじゃあstr2boolじゃないですね。すいませんまだバージョン0.1.xなので仕様が固まってないです。もうちょっと落ち着くまで色々ブレると思いますが勘弁してください。
- `raw_command_logging` で検出する改行コードを変更
  昨日CRじゃなくてLFで判定するようにしたよ！って書いたけど、ログ出力分ける際に改行コードを見る場合はCRじゃないとその行を取得できませんでしたorz
- サンプルファイルの更新
  昨日と今日改修分のサンプルファイルを直しました。

これで一旦v0.2に上げてもいいかなぁ。って感じなので上げます。でもまだまだメジャーバージョンリリースは程遠い。。。