### PR TITLE
v0.2.1

### DIFF
--- a/api/_global/connect.ttl
+++ b/api/_global/connect.ttl
@@ -5,6 +5,9 @@
 ; [入力値]
 ; (string)protocol: 接続種別(console/telnet/ssh)
 ; その他接続種別に依存した入力値は console-*.ttl を参照してください。
+; (string)group: マルチキャストグループ
+; 複数端末にマルチキャストメッセージを送信するための設定ですが、
+; teratermマクロからの制御はかなり限られてしまうため、現状では設定のみです。
 
 ; [戻り値]
 ; (integer)result: 試行結果(0で失敗、1以上で成功)
@@ -15,6 +18,7 @@ if result == 0 then
   protocol = 'console'
 elseif result != 3 then
   result = 0
+  message = '(Connect) Invalid variable type.'
   exit
 endif
 
@@ -28,6 +32,15 @@ sprintf 'api\_global\connect_%s.ttl' protocol
 include inputstr
 if result = 0 then
   exit
+endif
+
+ifdefined group
+if result == 3 then
+  strlen group
+  if result > 0 then
+    setmulticastname group
+  endif
+  group = ''
 endif
 
 timeout = 0

--- a/api/_global/connect_console.ttl
+++ b/api/_global/connect_console.ttl
@@ -9,6 +9,13 @@
 ; [戻り値]
 ; (integer)result: 接続ポート(0で接続失敗)
 
+testlink
+if result == 2 then
+  result = 0
+  message = '(Connect) connection is established yet'
+  exit
+endif
+
 _connected_port = 0
 str2int _port port
 

--- a/api/_global/connect_ssh.ttl
+++ b/api/_global/connect_ssh.ttl
@@ -13,6 +13,13 @@
 ; [戻り値]
 ; (integer)result: 接続成否(0で接続失敗)
 
+testlink
+if result == 2 then
+  result = 0
+  message = '(Connect) connection is established yet'
+  exit
+endif
+
 ifdefined port
 if result = 0 then
   _port = 22

--- a/api/_global/connect_telnet.ttl
+++ b/api/_global/connect_telnet.ttl
@@ -8,6 +8,13 @@
 ; [戻り値]
 ; (integer)result: 接続成否(0で接続失敗)
 
+testlink
+if result == 2 then
+  result = 0
+  message = '(Connect) connection is established yet'
+  exit
+endif
+
 ifdefined port
 if result = 0 then
   _port = 23

--- a/api/_global/disconnect.ttl
+++ b/api/_global/disconnect.ttl
@@ -1,0 +1,13 @@
+; disconnect.ttl
+; 通信を切断します。
+; Teratermとマクロ間のリンクは切れないため、再接続時にTeratermウインドウが新しく立ち上がることはありません。
+; 新しくウインドウを立ち上げたい場合は`unlink`を利用してください。
+
+; [入力値]
+; (string)dialog: ダイアログ表示(default:on)
+; 未設定、未定義等の場合はデフォルト値が入ります
+
+variable = 'dialog'
+include 'lib\str\str2bool.ttl'
+
+disconnect (result > 0)

--- a/api/_global/disconnect_force.ttl
+++ b/api/_global/disconnect_force.ttl
@@ -1,4 +1,0 @@
-; disconnect_force.ttl
-; 確認ダイアログを表示せずに切断します。
-
-disconnect 0

--- a/api/_global/goto.ttl
+++ b/api/_global/goto.ttl
@@ -1,0 +1,51 @@
+; goto.ttl
+; 直前の実行結果を評価して特定のラベルへジャンプします。
+
+; [入力値]
+; (string)on_success: 成功時ジャンプ先セクション
+; (string)on_error: 失敗時ジャンプ先セクション
+; (string)on_exception: 例外時ジャンプ先ラベル
+; このAPIは、直前の実行結果( `result` の値)を評価します。
+; result結果は、1以上: 成功、0:失敗、-1以下: 例外(致命的エラー)として分類されています。
+; 各ジャンプ先セクションを指定しなかった場合は、評価が該当してもジャンプせずに次へ進みます。
+
+; [戻り値]
+; (integer)result: 評価結果(1でジャンプ成功、0でジャンプ指定なし、-1でジャンプ失敗)
+; 成功時の具体的な数値については console-*.ttl を参照してください。
+
+_on = ''
+if api_result == 0
+  strlen on_error
+  if api_result == 0 exit
+  _on = on_error
+elseif result > 1 then
+  strlen on_success
+  if api_result == 0 exit
+  _on = on_success
+else
+  strlen on_exception
+  if api_result == 0 then exit
+  endif
+  _on = on_exception
+endif
+
+sprintf2 _command '_s_value = ini_secs_%s[_i]' refname
+for _i 0 _scenario_size
+  api_continue = 1
+  execcmnd _command
+  strcompare _s_value _on
+  if result == 0 then
+    _scenario_i = _i - 1
+    break
+  endif
+next
+
+if _i != _scenario_i + 1 then
+  result = -1
+else
+  result = 1
+endif
+
+on_success = ''
+on_error = ''
+on_exception = ''

--- a/api/_global/unlink.ttl
+++ b/api/_global/unlink.ttl
@@ -1,4 +1,6 @@
 ; unlink.ttl
 ; 現在のTeratermウインドウとTeracotta間のリンクを絶ちます
+; 再接続した際に新たにTeratermウインドウを開きます。
+; 同じウインドウを再利用したい場合はdisconnectを利用してください。
 
 unlink

--- a/api/_global/unlink.ttl
+++ b/api/_global/unlink.ttl
@@ -1,0 +1,4 @@
+; unlink.ttl
+; 現在のTeratermウインドウとTeracotta間のリンクを絶ちます
+
+unlink

--- a/lib/sys/_init.ttl
+++ b/lib/sys/_init.ttl
@@ -1,6 +1,6 @@
 ; initialize tool'
 _init_ver = '4.78'
-teracotta_ver = '0.2.0'
+teracotta_ver = '0.2.1'
 api_ver = '0.1.2'
 
 TC_ENCODING = 'SJIS'

--- a/lib/sys/_scenario.ttl
+++ b/lib/sys/_scenario.ttl
@@ -15,7 +15,7 @@ if result == 0 then
 endif
 
 ifdefined type
-if result = 3 then
+if result == 3 then
   sprintf 'scenario\%s\%s.ini' type scenario
   call _include_scenario
 endif
@@ -31,7 +31,7 @@ exit
 :_include_scenario
 filename = inputstr
 filesearch filename
-if result = 1 then
+if result == 1 then
   visibility = debug
   sprintf2 message '===== Load scenario: %s =====' scenario
   include 'lib\sys\log.ttl'
@@ -52,12 +52,13 @@ if result = 1 then
     include 'lib\ini\export-section.ttl'
 
     include 'lib\sys\_api.ttl'
-    if result = 0 then
+    api_result = result
+    if result == 0 then
       sprintf2 message '(Scenario) API terminate on error: %s' API
       include 'lib\sys\log.ttl'
     endif
 
-    if api_continue = 0 then
+    if api_continue == 0 then
       break
     endif
   next

--- a/teracotta.ttl
+++ b/teracotta.ttl
@@ -40,5 +40,8 @@ for inventory_row 0 csv_row__tc
   endif
 next
 
-closett
+testlink
+if result == 2 then
+  closett
+endif
 exit


### PR DESCRIPTION
- 新API `goto` ( #5 )
  直前のAPI実行結果を評価して、特定ラベルにジャンプします。
- 新API `unlink`
  Teratermマクロの `unlink` と同じ。Teraterm本体とマクロの接続を解除して再接続時に新たなウインドウを立ち上げることが出来ます。
- 機器接続時の動作を一部改善
- teracotta終了時の動作を一部改善